### PR TITLE
isAllowed should support multiple “User-agent” lines (case insensitive)

### DIFF
--- a/Robots.js
+++ b/Robots.js
@@ -128,7 +128,7 @@ function parseRobots(contents, robots) {
 				break;
 		}
 
-		isNoneUserAgentState = line[0] !== 'user-agent';
+		isNoneUserAgentState = line[0].toLowerCase() !== 'user-agent';
 	}
 }
 

--- a/test/Robots.js
+++ b/test/Robots.js
@@ -132,6 +132,19 @@ describe('Robots', function () {
 		done();
 	});
 
+	it('should support groups with multiple user agents (case insensitive)', function (done) {
+		var contents = [
+			'User-agent: agenta',
+			'User-agent: agentb',
+			'Disallow: /fish',
+		].join('\n');
+
+		var robots = robotsParser('http://www.example.com/robots.txt', contents);
+
+		expect(robots.isAllowed("http://www.example.com/fish", "agenta")).to.equal(false);
+		done();
+	});
+
 	it('should return undefined for invalid urls', function (done) {
 		var contents = [
 			'User-agent: *',


### PR DESCRIPTION
Robots.txt files with multiple "User-agent:" lines should be supported. Currently, these blocks only work if "user-agent" is in lowercase. This change makes the logic case insensitive.