### PR TITLE
Avoid using deprecated parts of the 'url' module.

### DIFF
--- a/Robots.js
+++ b/Robots.js
@@ -1,4 +1,4 @@
-var libUrl   = require('url');
+var URL      = require('url').URL;
 var punycode = require('punycode');
 
 /**
@@ -173,10 +173,26 @@ function isPathAllowed(path, rules) {
 	return result;
 }
 
+/**
+ * Converts provided string into an URL object.
+ * 
+ * Will return null if provided string is not a valid URL.
+ * 
+ * @param {string} url 
+ * @return {?URL}
+ * @private
+ */
+function parseUrl(url) {
+	try {
+		return new URL(url);
+	} catch(e) {
+		return null;
+	}
+}
 
 
 function Robots(url, contents) {
-	this._url = libUrl.parse(url);
+	this._url = parseUrl(url) || {};
 	this._url.port = this._url.port || 80;
 	this._url.hostname = punycode.toUnicode(this._url.hostname);
 
@@ -262,7 +278,7 @@ Robots.prototype.setPreferredHost = function (url) {
  * @return {boolean?}
  */
 Robots.prototype.isAllowed = function (url, ua) {
-	var parsedUrl = libUrl.parse(url);
+	var parsedUrl = parseUrl(url) || {};
 	var userAgent = formatUserAgent(ua || '*');
 
 	parsedUrl.port = parsedUrl.port || 80;
@@ -277,7 +293,7 @@ Robots.prototype.isAllowed = function (url, ua) {
 
 	var rules = this._rules[userAgent] || this._rules['*'] || [];
 
-	return isPathAllowed(parsedUrl.path, rules);
+	return isPathAllowed(parsedUrl.pathname + parsedUrl.search, rules);
 };
 
 /**


### PR DESCRIPTION
### Hi! 👋
Thank you so much for a wonderful project! We are using it in [GoogleChrome/lighthouse](https://github.com/GoogleChrome/lighthouse) in [one of the SEO audits](https://github.com/GoogleChrome/lighthouse/blob/7a1fb93328a45051f1cbf29ee69060314d8d909b/lighthouse-core/audits/seo/is-crawlable.js#L106).

### This PR
Short story: robots-parser uses some 'url' module APIs that are deprecated since Node v6, lets update them!

Long story: Lighthouse runs in both node and browser environments. In the browser we use the native [URL object](https://developer.mozilla.org/en-US/docs/Web/API/URL) to polyfill `require('url')`. Unfortunately, robots-parser was using APIs that are not compatible with the browser's URL object (namely `parse` and `path`). Thankfully, these APIs are also deprecated in Node, so it does make sense to update them.

⚠️ that's a breaking change because by using `new URL()` we are dropping support for Node v4 here (which is in the maintenance mode till April 2018).