### PR TITLE
Use global URL constructor

### DIFF
--- a/Robots.js
+++ b/Robots.js
@@ -1,5 +1,3 @@
-var URL = require('url').URL;
-
 /**
  * Trims the white space from the start and end of the line.
  *


### PR DESCRIPTION
A much later follow-up to #8 :)

We're still happy `robots-parser` users over in [GoogleChrome/lighthouse](https://github.com/GoogleChrome/lighthouse). Recently we've been changing how we bundle Lighthouse for use in the browser, and, for whatever reason, the most popular rollup and browserify polyfills for the Node `'url'` module don't include the `URL` property, requiring an extra level of patching to get `robots-parser` working in the browser.

Node 10 added [`URL` as a global](https://nodejs.org/api/globals.html#globals_url), though, which was released long enough ago that maybe the explicit `require()` could be dropped and the global used instead?

Thanks!