### PR TITLE
Fix CommonJS type export so the default import resolves under node16/nodenext

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-declare module 'robots-parser';
-
 interface Robot {
 	isAllowed(url: string, ua?: string): boolean | undefined;
 	isDisallowed(url: string, ua?: string): boolean | undefined;
@@ -10,4 +8,6 @@ interface Robot {
 	getPreferredHost(): string | null;
 }
 
-export default function robotsParser(url: string, robotstxt: string): Robot;
+declare function robotsParser(url: string, robotstxt: string): Robot;
+
+export = robotsParser;


### PR DESCRIPTION
> **Backwards compatibility:** No breaking change — existing code keeps working. Today the types resolve to `any`, so there's no real type contract to break; this just makes `import`/`require` correctly typed. Safe as a patch release.

## Problem

`index.d.ts` doesn't match the runtime. `index.js` is CommonJS:

```js
module.exports = function (url, contents) { ... };
```

but the types say:

```ts
declare module 'robots-parser';                     // (1)
export default function robotsParser(...): Robot;   // (2)
```

1. `declare module 'robots-parser';` has an empty body, so TypeScript types the **whole module as `any`**. The `Robot` interface right below it is never applied to what you import — every consumer gets `any` today.
2. `export default` doesn't describe `module.exports = fn`. Under `moduleResolution: node16` / `nodenext` (the modern default), the default import doesn't line up with the CommonJS export.

## Fix

Describe the actual CommonJS shape. One file, no runtime change:

```ts
declare function robotsParser(url: string, robotstxt: string): Robot;

export = robotsParser;
```

## Why this doesn't need a major version bump

Because `declare module 'robots-parser';` currently resolves the module to `any`, **no one has working type-checking against this package today.** This PR adds accurate types over what was effectively untyped — it can't break a type contract that never existed.

Every import style that works today keeps working:

| Import style | Today | After |
| --- | --- | --- |
| `import r from 'robots-parser'` (with `esModuleInterop`, or `node16`/`nodenext`) | `any` | typed function |
| `import r = require('robots-parser')` | `any` | typed function |
| `const r = require('robots-parser')` | works | works |

The only case that changes is `import r from 'robots-parser'` with `esModuleInterop: false` on classic module resolution — which is **already broken at runtime** (`module.exports` has no `.default`, so `r` is `undefined`). After this change that becomes a clear compile error pointing to `import r = require('robots-parser')`, instead of failing silently.

Strictly better types, nothing that currently type-checks breaks → patch release.
